### PR TITLE
Minor improvements for hyprland.conf

### DIFF
--- a/src/hyprland.conf
+++ b/src/hyprland.conf
@@ -9,17 +9,15 @@ misc {
 }
 
 input {
-numlock_by_default = true
+    numlock_by_default = true
 }
 
 cursor {
-no_warps = 1
+    no_warps = 1
 }
 
 # This rules only apply when using xdg-shell https://wiki.archlinux.org/title/SDDM#Wayland
 windowrulev2 = workspace emptym,fullscreen, stayfocused, decorate 0, noanim, noborder, nodim, norounding, noshadow, class:^(sddm-greeter)$
-
-
 
 # hyprlang noerror true
 

--- a/src/hyprland.conf
+++ b/src/hyprland.conf
@@ -34,6 +34,6 @@ source = /var/tmp/hyde/sddm.conf
 source = /var/tmp/hyde/monitors.conf
 source = /var/tmp/hyde/monitors/*.conf
 
-# hyprlang noerro false
+# hyprlang noerror false
 
 exec-once = hyprctl setcursor $CURSOR_THEME $CURSOR_SIZE


### PR DESCRIPTION
This is a tiny improvements for hyprland.conf
1. Fixed typo in `hyprlang noerro[r] false` directive
2. Added padding to embedded parameters