### PR TITLE
fix: disable popups which can prevent using sddm correctly

### DIFF
--- a/src/hyprland.conf
+++ b/src/hyprland.conf
@@ -1,6 +1,11 @@
 $CURSOR_THEME=Bibata-Modern-Ice
 $CURSOR_SIZE=24
 
+ecosystem {
+    enforce_permissions = false
+    no_update_news = true
+    no_donation_nag = true
+}
 
 misc {
     disable_hyprland_logo = true


### PR DESCRIPTION
Hyprland update/donation popups can interrupt using sddm correctly bacause are showed fullscreen and overlaps sddm window.

This PR disables popups using settings for the [docs](https://wiki.hypr.land/Configuring/Variables/#ecosystem)